### PR TITLE
[DO NOT MERGE] Params to help tease out race condition

### DIFF
--- a/benches/msm.rs
+++ b/benches/msm.rs
@@ -15,7 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let bench_npow = std::env::var("BENCH_NPOW").unwrap_or("26".to_string());
     let npoints_npow = i32::from_str(&bench_npow).unwrap();
 
-    let batches = 4;
+    let batches = 1;
     let (points, scalars) =
         util::generate_points_scalars::<G1Affine>(1usize << npoints_npow, batches);
     let mut context = multi_scalar_mult_init(points.as_slice());

--- a/tests/msm.rs
+++ b/tests/msm.rs
@@ -13,10 +13,10 @@ use blst_msm::*;
 
 #[test]
 fn msm_correctness() {
-    let test_npow = std::env::var("TEST_NPOW").unwrap_or("15".to_string());
+    let test_npow = std::env::var("TEST_NPOW").unwrap_or("11".to_string());
     let npoints_npow = i32::from_str(&test_npow).unwrap();
 
-    let batches = 4;
+    let batches = 1;
     let (points, scalars) =
         util::generate_points_scalars::<G1Affine>(1usize << npoints_npow, batches);
 


### PR DESCRIPTION
I'm fairly sure the pippenger kernel's `is_unique` function suffers from the insidious just-one-syncthreads-in-a-loop-with-smem gotcha.

Specifically, there's a race condition on [wvals](https://github.com/yelhousni/zprize-GPU-MSM-harness/blob/cf4f41519399e78f1a5f9c070554e37243b68772/sppark/msm/pippenger.cuh#L83). Because there's only one `__syncthreads` after each thread posts [`wvals[tid] = wval;`](https://github.com/yelhousni/zprize-GPU-MSM-harness/blob/cf4f41519399e78f1a5f9c070554e37243b68772/sppark/msm/pippenger.cuh#L87), any thread may race ahead to the next iteration of [this loop](https://github.com/yelhousni/zprize-GPU-MSM-harness/blob/cf4f41519399e78f1a5f9c070554e37243b68772/sppark/msm/pippenger.cuh#L185) and write a new value to `wvals` while other threads are still [here](https://github.com/yelhousni/zprize-GPU-MSM-harness/blob/main/sppark/msm/pippenger.cuh#L97) trying to consume the previous iteration's values. 

This PR helps expose the race condition, which interestingly manifests as a hang (at least that's what I see when I `cargo test` the diffs on an A10G). I need to understand the loop exit condition better to be sure why it hangs instead of yielding incorrect values. Regardless, uncommenting the added [`__syncthreads()`](https://github.com/yelhousni/zprize-GPU-MSM-harness/compare/main...mcarilli:zprize-GPU-MSM-harness:expose_race_condition?expand=1#diff-73e096f2cb860a76b0503e9d9e02013a58a58ff1aba3c02c7d31f12b6e337e69R111) fixes the issue: it prevents any thread from continuing until all threads read the values they need from `wvals`.

This PR is not meant for merge, just as a minimal set of diffs that reliably show the race condition. https://github.com/yelhousni/zprize-GPU-MSM-harness/pull/2/files is meant to be the fix. I prefer a separate PR for the fix (as opposed to modifying this PR to become the fix) because it's a cool, subtle issue and a public unaltered minimal repro is educational.